### PR TITLE
[Fix] Correct the instruction file. It is now called mission and uses th...

### DIFF
--- a/src/plm/core/model/tracking/GitSpy.java
+++ b/src/plm/core/model/tracking/GitSpy.java
@@ -59,7 +59,7 @@ public class GitSpy implements ProgressSpyListener {
 		String exoCode = exo.getSourceFile(lastResult.language, 0).getBody(); // retrieve the code from the student
 		String exoError = lastResult.compilationError; // retrieve the compilation error
 		String exoCorrection = exo.getSourceFile(lastResult.language, 0).getCorrection(); // retrieve the correction
-		String exoInstructions = Game.getInstance().getCurrentLesson().getAbout(); // retrieve the instructions
+		String exoMission = exo.getMission(lastResult.language); // retrieve the mission
 
 		// create the different files
 		String repoDir = repository.getDirectory().getParent();
@@ -68,12 +68,9 @@ public class GitSpy implements ProgressSpyListener {
 		File exoFile = new File(repoDir, exo.getId() + ext + ".code");
 		File errorFile = new File(repoDir, exo.getId() + ext + ".error");
 		File correctionFile = new File(repoDir, exo.getId() + ext + ".correction");
-		File instructionsFile = new File(repoDir, exo.getId() + ".instructions");
+		File missionFile = new File(repoDir, exo.getId() + ext + ".mission");
 
 		try {
-			exoFile.createNewFile();
-			errorFile.createNewFile();
-
 			// write the code of the exercise into the file
 			FileWriter fwExo = new FileWriter(exoFile.getAbsoluteFile());
 			BufferedWriter bwExo = new BufferedWriter(fwExo);
@@ -93,10 +90,10 @@ public class GitSpy implements ProgressSpyListener {
 			bwCorrection.close();
 
 			// write the instructions of the exercise into the file
-			FileWriter fwInstructions = new FileWriter(instructionsFile.getAbsoluteFile());
-			BufferedWriter bwInstructions = new BufferedWriter(fwInstructions);
-			bwInstructions.write(exoInstructions == null ? "" : exoInstructions);
-			bwInstructions.close();
+			FileWriter fwMission = new FileWriter(missionFile.getAbsoluteFile());
+			BufferedWriter bwMission = new BufferedWriter(fwMission);
+			bwMission.write(exoMission == null ? "" : exoMission);
+			bwMission.close();
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
...e getMission method to get its content. There is also now one mission file per language, as the getMission method take the current language as an argument.
# Explanations

Referring to my last pull request... Actually I checked again about what i've said concerning the instruction file and it appeared that I wasn't using the good method to retrieve the mission. Indeed I was using:
    Game.getInstance().getCurrentLesson().getAbout();
which is what we get when we click on "Help -> About current lesson" whereas we wanted the mission...
So now I use this method that I hadn't found the first time:
    String exoMission = exo.getMission(lastResult.language);
which gives us exactly what we need, but this method takes the langage as a parameter, so I also had to create one mission file per exercise.

To sum up, there is now a file per language for each type of file (code, error, correction, mission).
