### PR TITLE
Fix a bug from GitSpy overwriting current files by the last result's one...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
   * Engine:
     - #224: If the execution is interrupted, the exercise is failed
     - #380: Disable creative mode when switching the exercise
+    - GitSpy: Fix a bug which overwrote the current exercise's files
+      for the current programming language by the current exercise's files
+      for the last result's programming language
   * Worlds:
     - Turtle: equal() was not detecting when lines are overlapping
       with no common extremities. We now detect when one line is

--- a/src/plm/core/model/tracking/GitSpy.java
+++ b/src/plm/core/model/tracking/GitSpy.java
@@ -253,7 +253,7 @@ public class GitSpy implements ProgressSpyListener, UserSwitchesListener {
 		String exoMission = exo.getMission(lastResult.language); // retrieve the mission
 
 		// create the different files
-		String ext = "." + Game.getProgrammingLanguage().getExt();
+		String ext = "." + lastResult.language.getExt();
 
 		File exoFile = new File(repoDir, exo.getId() + ext + ".code");
 		File errorFile = new File(repoDir, exo.getId() + ext + ".error");


### PR DESCRIPTION
...s when switching exercises
