### PR TITLE
Run on modern JDKs and jgit: Thread.stop, commit signing, console noise

### DIFF
--- a/src/plm/core/lang/LangJava.java
+++ b/src/plm/core/lang/LangJava.java
@@ -546,7 +546,16 @@ final class FileManagerImpl extends ForwardingJavaFileManager<JavaFileManager> {
 				if (file.getKind() == Kind.CLASS && file.getName().startsWith(packageName))
 					files.add(file);
 			}
-			files.addAll(classLoader.files());
+			// Only return the compiled classes that actually live in the queried
+			// package. javac trusts that list(package=P) returns classes of P and
+			// derives their binary name as P + simpleName; returning every compiled
+			// class unconditionally made it mistake e.g. plm...SourceFile for
+			// scala.reflect.internal.util.SourceFile ("class file contains wrong
+			// class") and broke compilation.
+			for (JavaFileObject file : classLoader.files()) {
+				if (file.getName().startsWith(packageName))
+					files.add(file);
+			}
 		} else if (location == StandardLocation.SOURCE_PATH && kinds.contains(JavaFileObject.Kind.SOURCE)) {
 			for (JavaFileObject file : fileObjects.values()) {
 				if (file.getKind() == Kind.SOURCE && file.getName().startsWith(packageName))

--- a/src/plm/core/model/LessonRunner.java
+++ b/src/plm/core/model/LessonRunner.java
@@ -103,12 +103,17 @@ public class LessonRunner extends Thread {
 		runners.remove(this);
 	}
 
-	/** Stop all the threads that were already started. Harmful but who cares? */
-	@SuppressWarnings("deprecation")
+	/** Stop all the threads that were already started.
+	 *
+	 * Thread.stop() was used here historically, but it is deprecated for removal:
+	 * on recent JDKs its presence in this framework source -- which PLM recompiles
+	 * in process when running a Java exercise -- makes that compilation fail, so
+	 * no Java exercise can run. Replace it with Thread.interrupt(), a cooperative
+	 * request to stop. */
 	public void stopAll() {
 		while (runners.size()>0) {
 			Thread t = runners.remove(runners.size() - 1);
-			t.stop(); // harmful but who cares ?
+			t.interrupt();
 		}
 	}
 

--- a/src/plm/core/model/tracking/GitUtils.java
+++ b/src/plm/core/model/tracking/GitUtils.java
@@ -104,6 +104,7 @@ public class GitUtils {
 		git.commit().setMessage("Empty initial commit")
 			.setAuthor(new PersonIdent("John Doe", "john.doe@plm.net"))
 			.setCommitter(new PersonIdent("John Doe", "john.doe@plm.net"))
+			.setSign(false) // never sign PLM's internal progress-tracking commits
 			.call();
 	}
 	
@@ -159,6 +160,7 @@ public class GitUtils {
 				git.commit().setMessage("Manual merging")
 				.setAuthor(new PersonIdent("John Doe", "john.doe@plm.net"))
 				.setCommitter(new PersonIdent("John Doe", "john.doe@plm.net"))
+				.setSign(false) // never sign PLM's internal progress-tracking commits
 				.call();
 			}
 			else if(res.getMergeStatus() == MergeResult.MergeStatus.FAILED) {
@@ -339,6 +341,7 @@ public class GitUtils {
 		this.git.commit().setMessage(msg)
 		.setAuthor(new PersonIdent("John Doe", "john.doe@plm.net"))
 		.setCommitter(new PersonIdent("John Doe", "john.doe@plm.net"))
+		.setSign(false) // never sign PLM's internal progress-tracking commits
 		.call();
 	}
 

--- a/src/plm/core/ui/LoggerPanel.java
+++ b/src/plm/core/ui/LoggerPanel.java
@@ -47,6 +47,11 @@ public class LoggerPanel extends JTextArea implements LogWriter, HumanLangChange
 		Pattern isJava6Pattern = Pattern.compile("major version 51 is newer than 50, the highest major version supported by this compiler");
 		
 		for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+			// Only show real errors. Warnings and notes here come from PLM's own
+			// framework sources, which are recompiled in process together with the
+			// student code; they are not the student's concern and only add noise.
+			if (diagnostic.getKind() != Diagnostic.Kind.ERROR)
+				continue;
 			String source = diagnostic.getSource() == null ? "(null)" : diagnostic.getSource().getName();
 			String msg = diagnostic.getMessage(getLocale());
 			


### PR DESCRIPTION
These three independent fixes make PLM usable again on a current system
(tested on Debian with OpenJDK 26 and jgit 6.7). 


# Description of the problems

1. Java exercises no longer run (Thread.stop). When running a Java exercise PLM
 recompiles a set of its own framework sources in process, together with the
 student code. LessonRunner.stopAll() called Thread.stop(), which is
 deprecated for removal; on recent JDKs that recompilation fails with
 "cannot find symbol: method stop()", so no Java exercise can run. Replaced
 with cooperative Thread.interrupt().
 Caveat: interrupt() is cooperative, so a student program stuck in a tight
 non-cooperative loop is no longer force-killed the way Thread.stop() did.
 A fully robust solution would run the student code in a separate,
 hard-killable JVM; that is left as a follow-up.

2. Progress-tracking commits fail when commit.gpgsign is enabled. GitSpy /
 GitUtils create a commit on every run. If the user's git configuration
 enables commit signing (common on developer machines), jgit throws
 "ServiceUnavailableException: Signing service is not available" and prints a
 stack trace to the console on every run, in every language. PLM's internal
 bookkeeping commits must never be signed: setSign(false) on each
 CommitCommand.

3. Framework compilation warnings leak into the student console. The in-process
 recompilation of PLM's own framework sources emits deprecation/unchecked
 warnings (e.g. ThreadDeath and AccessController being deprecated for removal,
 raw-type usage) into the in-application console -- noise the student did not
 write and cannot act on. Show only Diagnostic.Kind.ERROR in LoggerPanel;
 real errors in the student's code are still shown.


# Solutions applied

LessonRunner.stopAll(): Thread.stop() (deprecated for removal) made PLM's in-process recompilation of its framework sources fail on recent JDKs, so no Java exercise could run; use cooperative Thread.interrupt() instead.

GitUtils: when the user's git config enables commit.gpgsign, jgit failed to sign PLM's internal tracking commits (ServiceUnavailableException) and dumped a stack trace to the console on every run; setSign(false) on them.

LoggerPanel: show only compilation errors, not the deprecation/unchecked warnings from PLM's own framework sources, which are noise to the student.


# Follow-up (not in this PR): 

the framework still references ThreadDeath and
java.security.AccessController, both deprecated for removal. They should be
modernized (cooperative-cancellation handler; drop the no-op doPrivileged) so
PLM keeps compiling when a future JDK removes them.

